### PR TITLE
Deactivate Tokens if password changed by user.

### DIFF
--- a/prisma/migrations/20250614112250_added_password_changed_at_date_time_in_users_table/migration.sql
+++ b/prisma/migrations/20250614112250_added_password_changed_at_date_time_in_users_table/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Users" ADD COLUMN     "passwordChangedAt" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -12,6 +12,7 @@ model User {
   id        Int      @id @default(autoincrement())
   password  String
   email     String   @unique
+  passwordChangedAt DateTime?
   doctor Doctor?
   patient Patient?
   createdAt DateTime @default(now())


### PR DESCRIPTION
Adds `passwordChangedAt` field to the User model in Prisma schema and database.

Implements JWT invalidation logic based on password change time.  If a user changes their password, existing JWTs issued before the change are invalidated, forcing the user to log in again. This enhances security by preventing the use of old tokens after a password reset.

Fixes #5 issue
handle password changed by user.